### PR TITLE
FEAT/14: Set details on search

### DIFF
--- a/app/src/main/java/com/example/stylish/common/HttpRoutes.kt
+++ b/app/src/main/java/com/example/stylish/common/HttpRoutes.kt
@@ -8,9 +8,11 @@ object HttpRoutes {
     const val PRODUCT_LIST_ID_START = "$BASE_URL/getProductList?categoryId="
     const val PRODUCT_LIST_ID_END = "&currency=USD&country=US&store=US&languageShort=en&sizeSchema=US&limit=200&offset=0"
 
-    const val PRODUCT_LIST_TERM_START = "$BASE_URL/getProductListBySearchTerm?searchTerm="
-    const val PRODUCT_LIST_TERM_MIDDLE = "&currency=USD&country=US&store=US&languageShort=en&sizeSchema=US&limit=200&offset=1&priceMin="
-    const val PRODUCT_LIST_TERM_END = "&priceMax="
+    const val PRODUCT_LIST_TERM_TERM = "$BASE_URL/getProductListBySearchTerm?searchTerm="
+    const val PRODUCT_LIST_TERM_MIDDLE = "&currency=USD&country=US&store=US&languageShort=en&sizeSchema=US&limit=200&offset=0"
+    const val PRODUCT_LIST_TERM_SORT = "&sort="
+    const val PRODUCT_LIST_TERM_MIN = "&priceMin="
+    const val PRODUCT_LIST_TERM_MAX = "&priceMax="
 
     const val PRODUCT_DETAIL_START = "$BASE_URL/getProductDetails?productId="
     const val PRODUCT_DETAIL_END = "&currency=USD&store=US&language=en-US&sizeSchema=US"

--- a/app/src/main/java/com/example/stylish/data/remote/dto/AsosApiService.kt
+++ b/app/src/main/java/com/example/stylish/data/remote/dto/AsosApiService.kt
@@ -11,6 +11,7 @@ interface AsosApiService {
     suspend fun getProductsByCategoryId(id: Int): com.example.stylish.data.remote.dto.products_by_categoryId.ProductsByCategoryId
     suspend fun getProductsBySearchTerm(
         term: String,
+        sortType: String,
         minPrice: String,
         maxPrice: String
     ): ProductsBySearchTerm

--- a/app/src/main/java/com/example/stylish/data/remote/dto/AsosApiServiceImpl.kt
+++ b/app/src/main/java/com/example/stylish/data/remote/dto/AsosApiServiceImpl.kt
@@ -3,8 +3,10 @@ package com.example.stylish.data.remote.dto
 import com.example.stylish.common.HttpRoutes
 import com.example.stylish.data.remote.dto.category.Category
 import com.example.stylish.data.remote.dto.detail.Detail
+import com.example.stylish.data.remote.dto.products_by_categoryId.ProductsByCategoryId
 import com.example.stylish.data.remote.dto.products_by_searchTerm.ProductsBySearchTerm
 import com.example.stylish.data.remote.dto.you_might_also_like.YouMightAlsoLike
+import com.example.stylish.presentation.search.main.SortType
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -12,32 +14,40 @@ import javax.inject.Inject
 
 class AsosApiServiceImpl @Inject constructor(
     private val client: HttpClient
-): AsosApiService {
+) : AsosApiService {
     override suspend fun getCategories(): Category {
         return client.get(HttpRoutes.CATEGORY).body()
     }
 
-    override suspend fun getProductsByCategoryId(id: Int): com.example.stylish.data.remote.dto.products_by_categoryId.ProductsByCategoryId {
-        return client.get(HttpRoutes.PRODUCT_LIST_ID_START + id + HttpRoutes.PRODUCT_LIST_ID_END).body()
+    override suspend fun getProductsByCategoryId(id: Int): ProductsByCategoryId {
+        return client.get(HttpRoutes.PRODUCT_LIST_ID_START + id + HttpRoutes.PRODUCT_LIST_ID_END)
+            .body()
     }
 
     override suspend fun getProductsBySearchTerm(
         term: String,
+        sortType: String,
         minPrice: String,
         maxPrice: String
     ): ProductsBySearchTerm {
         return client.get(
-            HttpRoutes.PRODUCT_LIST_TERM_START + term +
-            HttpRoutes.PRODUCT_LIST_TERM_MIDDLE + minPrice +
-            HttpRoutes.PRODUCT_LIST_TERM_END + maxPrice
+            HttpRoutes.PRODUCT_LIST_TERM_TERM + term +
+                    HttpRoutes.PRODUCT_LIST_TERM_MIDDLE +
+                    if (sortType != SortType.None.type) {
+                        HttpRoutes.PRODUCT_LIST_TERM_SORT + sortType
+                    } else { "" } +
+                    HttpRoutes.PRODUCT_LIST_TERM_MIN + minPrice +
+                    HttpRoutes.PRODUCT_LIST_TERM_MAX + maxPrice
         ).body()
     }
 
     override suspend fun getItemDetailById(id: Int): Detail {
-        return client.get(HttpRoutes.PRODUCT_DETAIL_START + id + HttpRoutes.PRODUCT_DETAIL_END).body()
+        return client.get(HttpRoutes.PRODUCT_DETAIL_START + id + HttpRoutes.PRODUCT_DETAIL_END)
+            .body()
     }
 
     override suspend fun getYouMightAlsoLike(id: Int): YouMightAlsoLike {
-        return client.get(HttpRoutes.YOU_MIGHT_ALSO_LIKE_START + id + HttpRoutes.YOU_MIGHT_ALSO_LIKE_END).body()
+        return client.get(HttpRoutes.YOU_MIGHT_ALSO_LIKE_START + id + HttpRoutes.YOU_MIGHT_ALSO_LIKE_END)
+            .body()
     }
 }

--- a/app/src/main/java/com/example/stylish/data/remote/dto/products_by_searchTerm/Diagnostics.kt
+++ b/app/src/main/java/com/example/stylish/data/remote/dto/products_by_searchTerm/Diagnostics.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Diagnostics(
     @SerialName("requestId")
-    val requestId: String,
+    val requestId: String? = null,
     @SerialName("processingTime")
     val processingTime: Int,
     @SerialName("queryTime")

--- a/app/src/main/java/com/example/stylish/data/remote/repository/AsosRepositoryImpl.kt
+++ b/app/src/main/java/com/example/stylish/data/remote/repository/AsosRepositoryImpl.kt
@@ -21,13 +21,15 @@ class AsosRepositoryImpl @Inject constructor(
 
     override suspend fun getProductsBySearchTerm(
         term: String,
+        sortType: String,
         minPrice: String,
         maxPrice: String
     ): ProductsBySearchTerm {
         return api.getProductsBySearchTerm(
             term = term,
             minPrice = minPrice,
-            maxPrice = maxPrice
+            maxPrice = maxPrice,
+            sortType = sortType
         )
     }
 

--- a/app/src/main/java/com/example/stylish/di/AppModule.kt
+++ b/app/src/main/java/com/example/stylish/di/AppModule.kt
@@ -43,7 +43,7 @@ object AppModule {
             // Must delete before push!!!
             // -------------------------------------------------------------------------------------
             install(DefaultRequest) {
-                header("X-RapidAPI-Key", "2cff06b069msh1ea287b3f59bd42p139a51jsn8c4f1a12d488")
+                header("X-RapidAPI-Key", "")
                 header("X-RapidAPI-Host", "asos10.p.rapidapi.com")
             }
             // -------------------------------------------------------------------------------------

--- a/app/src/main/java/com/example/stylish/di/AppModule.kt
+++ b/app/src/main/java/com/example/stylish/di/AppModule.kt
@@ -43,7 +43,7 @@ object AppModule {
             // Must delete before push!!!
             // -------------------------------------------------------------------------------------
             install(DefaultRequest) {
-                header("X-RapidAPI-Key", "")
+                header("X-RapidAPI-Key", "2cff06b069msh1ea287b3f59bd42p139a51jsn8c4f1a12d488")
                 header("X-RapidAPI-Host", "asos10.p.rapidapi.com")
             }
             // -------------------------------------------------------------------------------------

--- a/app/src/main/java/com/example/stylish/domain/repository/AsosRepository.kt
+++ b/app/src/main/java/com/example/stylish/domain/repository/AsosRepository.kt
@@ -13,6 +13,7 @@ interface AsosRepository {
 
     suspend fun getProductsBySearchTerm(
         term: String,
+        sortType: String,
         minPrice: String,
         maxPrice: String
     ): ProductsBySearchTerm

--- a/app/src/main/java/com/example/stylish/domain/viewModel/SharedViewModel.kt
+++ b/app/src/main/java/com/example/stylish/domain/viewModel/SharedViewModel.kt
@@ -22,10 +22,22 @@ class SharedViewModel @Inject constructor(
     private val _categoryNameWithId = mutableStateOf<List<CategoryNameWithId>>(listOf())
     val categoryNameWithId: State<List<CategoryNameWithId>> = _categoryNameWithId
 
-    fun getCategoryByGender(gender: String) {
-        val gender = if (gender == "Men") 0 else 1
+    private val _menWomenImage = mutableStateOf<List<String>>(listOf())
+    val menWomenImage: State<List<String>> = _menWomenImage
+
+    fun getMenWomenImage() {
         viewModelScope.launch {
-            _category.value = service.getCategories().data?.navigation?.get(gender)?.children?.get(4)?.children?.find { it.content?.title == "Clothing" }?.children?.get(1)?.children
+            _menWomenImage.value = service.getCategories().data?.navigation?.map {
+                it.children?.get(4)?.children?.find { it2 ->
+                    it2.content?.title == "Clothing"
+                }?.content?.mobileImageUrl.toString()
+            }?: listOf()
+        }
+    }
+
+    fun getCategoryByGender(gender: String) {
+        viewModelScope.launch {
+            _category.value = service.getCategories().data?.navigation?.get(if (gender == "Men") 0 else 1)?.children?.get(4)?.children?.find { it.content?.title == "Clothing" }?.children?.get(1)?.children
                 ?: listOf()
             _categoryNameWithId.value = category.value.map { CategoryNameWithId(name = it.content?.title, id = it.link?.categoryId) }
         }

--- a/app/src/main/java/com/example/stylish/graphs/MainNavGraph.kt
+++ b/app/src/main/java/com/example/stylish/graphs/MainNavGraph.kt
@@ -6,8 +6,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.stylish.presentation.create.CreateScreen
-import com.example.stylish.presentation.home.HomeScreen
-import com.example.stylish.presentation.mypage.MyPageScreen
+import com.example.stylish.presentation.wishlist.WishListScreen
 
 @Composable
 fun MainNavGraph(
@@ -31,7 +30,7 @@ fun MainNavGraph(
             paddingValues = paddingValues
         )
         composable(route = MainGraph.MyPageScreen.route) {
-            MyPageScreen(
+            WishListScreen(
                 navController = navController,
                 paddingValues = paddingValues
             )

--- a/app/src/main/java/com/example/stylish/presentation/home/component/ItemInfoScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/home/component/ItemInfoScreen.kt
@@ -2,26 +2,41 @@ package com.example.stylish.presentation.home.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
+import com.example.stylish.data.local.viewModel.WishlistViewModel
+import com.example.stylish.data.local.wishlistDatabase.Wishitem
 import com.example.stylish.graphs.HomeDetailScreen
 import com.example.stylish.graphs.RootGraph
 import java.util.Locale
@@ -33,21 +48,27 @@ fun ItemInfoScreen(
     itemId: Int,
     itemName: String,
     imageUrl: String,
-    price: String
+    price: String,
+    dbViewModel: WishlistViewModel = hiltViewModel()
 ) {
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
+        // Observe wishList directly to handle LiveData changes
+        val wishList by dbViewModel.wishList.observeAsState(initial = emptyList())
+
+        // Observe wishList to update isBookmarked
+        var isBookmarked by remember(wishList) {
+            mutableStateOf(wishList.any { it.itemId == itemId })
+        }
+
         Text(
-            modifier = Modifier
-                .padding(horizontal = 16.dp),
+            modifier = Modifier.padding(16.dp),
             text = brandName,
             style = LocalTextStyle.current.copy(
                 fontSize = 24.sp
             )
         )
-
-        Spacer(modifier = Modifier.height(4.dp))
 
         Text(
             modifier = Modifier
@@ -63,7 +84,7 @@ fun ItemInfoScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(314f/400f)
+                .aspectRatio(314f / 400f)
         ) {
             Image(
                 painter = image,
@@ -80,16 +101,47 @@ fun ItemInfoScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            text = price,
-            textAlign = TextAlign.End,
-            style = LocalTextStyle.current.copy(
-                fontSize = 20.sp
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = price,
+                style = LocalTextStyle.current.copy(
+                    fontSize = 20.sp
+                )
             )
-        )
+            IconButton(
+                onClick = {
+                    if (isBookmarked) {
+                        wishList.find { it.itemId == itemId }
+                            ?.let { dbViewModel.deleteWishItem(it) }
+                    } else {
+                        dbViewModel.addWishItem(
+                            Wishitem(
+                                itemId = itemId,
+                                brandName = brandName,
+                                price = price,
+                                imageUrl = imageUrl
+                            )
+                        )
+                    }
+                    isBookmarked = !isBookmarked
+                }
+            ) {
+                Icon(
+                    imageVector = if (isBookmarked) {
+                        Icons.Default.Bookmark
+                    } else {
+                        Icons.Default.BookmarkBorder
+                    },
+                    contentDescription = "Bookmark"
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(30.dp))
     }

--- a/app/src/main/java/com/example/stylish/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/stylish/presentation/main/MainViewModel.kt
@@ -42,7 +42,7 @@ class MainViewModel @Inject constructor(
             route = MainGraph.SearchScreen.route
         ),
         BottomNavigationItem(
-            title = "My Page",
+            title = "Wish List",
             selectedIcon = Icons.Filled.Person,
             unselectedIcon = Icons.Outlined.Person,
             route = MainGraph.MyPageScreen.route

--- a/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainScreen.kt
@@ -1,6 +1,7 @@
 package com.example.stylish.presentation.search.main
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -10,10 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.example.stylish.presentation.search.main.component.BeforeSearchScreen
+import com.example.stylish.presentation.search.main.component.Conditions
 import com.example.stylish.presentation.search.main.component.SearchBarM3
 import com.example.stylish.presentation.search.products.byTerm.ProductsByTermScreen
 
@@ -31,15 +34,16 @@ fun SearchMainScreen(
             .padding(paddingValues),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Spacer(modifier = Modifier.height(8.dp))
+
         SearchBarM3()
 
         if (!viewModel.isActive() && viewModel.getQuery().isNotEmpty()) {
             ProductsByTermScreen(
                 paddingValues = paddingValues,
                 term = viewModel.getQuery(),
-                minPrice = "0",
-                maxPrice = "0",
+                sortType = viewModel.sortType.value,
+                minPrice = viewModel.minPrice.value,
+                maxPrice = viewModel.maxPrice.value,
                 navController = navController
             )
         } else {
@@ -47,4 +51,3 @@ fun SearchMainScreen(
         }
     }
 }
-

--- a/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainScreen.kt
@@ -37,7 +37,9 @@ fun SearchMainScreen(
 
         SearchBarM3()
 
-        if (!viewModel.isActive() && viewModel.getQuery().isNotEmpty()) {
+        if (viewModel.getQuery().isEmpty()) {
+            BeforeSearchScreen(paddingValues = paddingValues, navController = navController)
+        } else {
             ProductsByTermScreen(
                 paddingValues = paddingValues,
                 term = viewModel.getQuery(),
@@ -46,8 +48,6 @@ fun SearchMainScreen(
                 maxPrice = viewModel.maxPrice.value,
                 navController = navController
             )
-        } else {
-            BeforeSearchScreen(paddingValues = paddingValues, navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainViewModel.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/SearchMainViewModel.kt
@@ -16,6 +16,15 @@ class SearchMainViewModel @Inject constructor(
     private val _active = mutableStateOf(false)
     val active: State<Boolean> = _active
 
+    private val _sortType = mutableStateOf(SortType.None.type)
+    val sortType: State<String> = _sortType
+
+    private val _minPrice = mutableStateOf("")
+    val minPrice: State<String> = _minPrice
+
+    private val _maxPrice = mutableStateOf("")
+    val maxPrice: State<String> = _maxPrice
+
     fun getQuery(): String {
         return _query.value
     }
@@ -31,4 +40,24 @@ class SearchMainViewModel @Inject constructor(
     fun toggleActive() {
         _active.value = !_active.value
     }
+
+    fun setSortType(type: String) {
+        _sortType.value = type
+    }
+
+    fun setMinPrice(price: String) {
+        _minPrice.value = price
+    }
+
+    fun setMaxPrice(price: String) {
+        _maxPrice.value = price
+    }
+}
+
+sealed class SortType(val type: String) {
+    data object None: SortType(type = "None")
+    data object Asc: SortType(type = "priceasc")
+    data object Dsc: SortType(type = "pricedesc")
+    data object Rec: SortType(type = "recommended")
+    data object New: SortType(type = "freshness")
 }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/BeforeSearchScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/BeforeSearchScreen.kt
@@ -36,7 +36,7 @@ fun BeforeSearchScreen(
         // Men & Women category cards
         if (viewModel.menWomenImage.value.isNotEmpty()) {
             GenderCard(gender = "Men", navController = navController, imageUrl = viewModel.menWomenImage.value[0])
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(50.dp))
             GenderCard(gender = "Women", navController = navController, imageUrl = viewModel.menWomenImage.value[1])
         }
     }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/BeforeSearchScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/BeforeSearchScreen.kt
@@ -3,27 +3,41 @@ package com.example.stylish.presentation.search.main.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.example.stylish.domain.viewModel.SharedViewModel
 
 @Composable
 fun BeforeSearchScreen(
     paddingValues: PaddingValues,
-    navController: NavController
+    navController: NavController,
+    viewModel: SharedViewModel = hiltViewModel()
 ) {
+    LaunchedEffect(Unit) {
+        viewModel.getMenWomenImage()
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(paddingValues),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly
+        verticalArrangement = Arrangement.Center
     ) {
         // Men & Women category cards
-        GenderCard(gender = "Men", navController = navController)
-        GenderCard(gender = "Women", navController = navController)
+        if (viewModel.menWomenImage.value.isNotEmpty()) {
+            GenderCard(gender = "Men", navController = navController, imageUrl = viewModel.menWomenImage.value[0])
+            Spacer(modifier = Modifier.height(16.dp))
+            GenderCard(gender = "Women", navController = navController, imageUrl = viewModel.menWomenImage.value[1])
+        }
     }
 }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/Conditions.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/Conditions.kt
@@ -1,0 +1,163 @@
+package com.example.stylish.presentation.search.main.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Divider
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.text.isDigitsOnly
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.stylish.presentation.search.main.SearchMainViewModel
+import com.example.stylish.presentation.search.main.SortType
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun Conditions(
+    viewModel: SearchMainViewModel = hiltViewModel()
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+    ) {
+        FlowRow(
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            // None
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = viewModel.sortType.value == SortType.None.type,
+                    onClick = { viewModel.setSortType(SortType.None.type) }
+                )
+                Text(text = "None")
+            }
+
+            // Ascending order
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = viewModel.sortType.value == SortType.Asc.type,
+                    onClick = { viewModel.setSortType(SortType.Asc.type) }
+                )
+                Text(text = "Ascending")
+            }
+
+            // Descending order
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = viewModel.sortType.value == SortType.Dsc.type,
+                    onClick = { viewModel.setSortType(SortType.Dsc.type) }
+                )
+                Text(text = "Descending")
+            }
+
+            // Sort by recommended
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = viewModel.sortType.value == SortType.Rec.type,
+                    onClick = { viewModel.setSortType(SortType.Rec.type) }
+                )
+                Text(text = "Recommended")
+            }
+
+            // Sort by freshness
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = viewModel.sortType.value == SortType.New.type,
+                    onClick = { viewModel.setSortType(SortType.New.type) }
+                )
+                Text(text = "Freshness")
+            }
+        }
+
+
+        val focusRequester = remember { FocusRequester() }
+        Column(
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 16.dp)
+        ) {
+            Text(text = "Price Range($)")
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextField(
+                    modifier = Modifier
+                        .width(150.dp)
+                        .focusRequester(focusRequester),
+                    value = viewModel.minPrice.value,
+                    onValueChange = {
+                        if (it.isDigitsOnly()) {
+                            viewModel.setMinPrice(it)
+                        }
+                    },
+                    label = { Text(text = "Minimum") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
+                    singleLine = true
+                )
+
+                Text(
+                    modifier = Modifier.padding(horizontal = 10.dp),
+                    text = "~",
+                    fontSize = 25.sp
+                )
+
+                TextField(
+                    modifier = Modifier.width(150.dp),
+                    value = viewModel.maxPrice.value,
+                    onValueChange = {
+                        if (it.isDigitsOnly()) {
+                            viewModel.setMaxPrice(it)
+                        }
+                    },
+                    label = { Text(text = "Maximum") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true
+                )
+            }
+        }
+
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/GenderCard.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/GenderCard.kt
@@ -1,6 +1,6 @@
 package com.example.stylish.presentation.search.main.component
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,58 +8,68 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.example.stylish.graphs.SearchDetailScreen
+import com.example.stylish.ui.theme.DancingScript
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GenderCard(
     gender: String,
-    navController: NavController
+    navController: NavController,
+    imageUrl: String
 ) {
+    val image = rememberAsyncImagePainter(model = imageUrl)
+
     Card(
         onClick = {
             navController.navigate(SearchDetailScreen.SearchCategoryScreen.route + "/${gender}")
         },
         modifier = Modifier
             .fillMaxWidth()
-            .aspectRatio(7f / 4f)
             .padding(horizontal = 38.dp),
         elevation = CardDefaults.cardElevation(5.dp)
     ) {
         Box(
             modifier = Modifier
-                .fillMaxSize(),
-            contentAlignment = Alignment.BottomStart
+                .fillMaxWidth()
+                .aspectRatio(400f / 133f),
+            contentAlignment = Alignment.TopStart
         ){
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.radialGradient(
-                            colors = listOf(Color(0xffededed), Color.Gray),
-                            center = Offset(270f, 330f),
-                            radius = 900f
-                        )
-                    )
+
+            Image(
+                painter = image,
+                contentDescription = "bar image",
+                modifier = Modifier.fillMaxSize()
             )
+            if (image.state is AsyncImagePainter.State.Loading) {
+                CircularProgressIndicator(
+                    Modifier.align(Alignment.Center)
+                )
+            }
+
             Text(
+                modifier = Modifier.padding(start = 24.dp),
                 text = gender,
-                modifier = Modifier.padding(start = 38.dp, bottom = 90.dp),
                 style = LocalTextStyle.current.copy(
+                    fontFamily = DancingScript,
                     fontSize = 58.sp,
-                    color = Color(0xff292929)
+                    color = Color.DarkGray,
+                    fontStyle = FontStyle.Italic
                 )
             )
         }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/SearchBarM3.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/SearchBarM3.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Search
@@ -63,14 +64,25 @@ fun SearchBarM3(
         trailingIcon = {
             if (viewModel.isActive()) {
                 IconButton(onClick = {
-                    if (viewModel.query.value.isNotEmpty())
-                        viewModel.setQuery("")
-                    else
+                    if (viewModel.query.value.isEmpty())
                         viewModel.toggleActive()
+                    else
+                        viewModel.setQuery("")
                 }) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Close"
+                    )
+                }
+            }
+
+            if (!viewModel.isActive() && viewModel.query.value.isNotEmpty()) {
+                IconButton(onClick = {
+                    viewModel.setQuery("")
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back to men and women"
                     )
                 }
             }

--- a/app/src/main/java/com/example/stylish/presentation/search/main/component/SearchBarM3.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/main/component/SearchBarM3.kt
@@ -1,6 +1,7 @@
 package com.example.stylish.presentation.search.main.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.History
@@ -27,6 +29,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.stylish.data.local.historyDatabase.History
@@ -85,6 +89,8 @@ fun SearchBarM3(
                 listState.animateScrollToItem(histories.size - 1)
             }
         }
+
+        Conditions()
 
         LazyColumn(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/stylish/presentation/search/products/byTerm/ProductsByTermScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/products/byTerm/ProductsByTermScreen.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -35,11 +38,13 @@ import androidx.navigation.NavHostController
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import com.example.stylish.graphs.RootGraph
+import com.example.stylish.presentation.search.main.component.SearchBarM3
 
 @Composable
 fun ProductsByTermScreen(
     paddingValues: PaddingValues,
     term: String,
+    sortType: String,
     minPrice: String,
     maxPrice: String,
     viewModel: ProductsByTermViewModel = hiltViewModel(),
@@ -50,6 +55,7 @@ fun ProductsByTermScreen(
         block = {
             viewModel.getProductByItemTerm(
                 term = term,
+                sortType = sortType,
                 minPrice = minPrice,
                 maxPrice = maxPrice
             )
@@ -63,7 +69,7 @@ fun ProductsByTermScreen(
         state = listState,
         modifier = Modifier
             .fillMaxSize()
-            .padding(top = paddingValues.calculateTopPadding(), start = 8.dp, end = 8.dp)
+            .padding(top = paddingValues.calculateTopPadding() + 8.dp, start = 8.dp, end = 8.dp)
     ) {
         items(viewModel.productList.value) { item ->
             Card(

--- a/app/src/main/java/com/example/stylish/presentation/search/products/byTerm/ProductsByTermViewModel.kt
+++ b/app/src/main/java/com/example/stylish/presentation/search/products/byTerm/ProductsByTermViewModel.kt
@@ -24,12 +24,14 @@ class ProductsByTermViewModel @Inject constructor(
 
     fun getProductByItemTerm(
         term: String,
+        sortType: String,
         minPrice: String,
         maxPrice: String
     ) {
         viewModelScope.launch {
             _data.value = service.getProductsBySearchTerm(
                 term = term,
+                sortType = sortType,
                 minPrice = minPrice,
                 maxPrice = maxPrice
             )     // 2623 is the id of the "New in" category.

--- a/app/src/main/java/com/example/stylish/presentation/wishlist/WishListScreen.kt
+++ b/app/src/main/java/com/example/stylish/presentation/wishlist/WishListScreen.kt
@@ -1,4 +1,4 @@
-package com.example.stylish.presentation.mypage
+package com.example.stylish.presentation.wishlist
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
@@ -8,12 +8,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -52,7 +50,7 @@ import com.example.stylish.ui.theme.DancingScript
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun MyPageScreen(
+fun WishListScreen(
     paddingValues: PaddingValues,
     navController: NavController,
     viewModel: WishlistViewModel = hiltViewModel()
@@ -132,7 +130,13 @@ fun MyPageScreen(
                                 contentAlignment = Alignment.BottomStart
                             ) {
                                 val image =
-                                    rememberAsyncImagePainter(model = "https://${item.imageUrl}")
+                                    rememberAsyncImagePainter(
+                                        model = if (item.imageUrl.contains("https://")) {
+                                            item.imageUrl
+                                        } else {
+                                            "https://${item.imageUrl}"
+                                        }
+                                    )
 
                                 if (image.state is AsyncImagePainter.State.Loading) {
                                     CircularProgressIndicator(

--- a/app/src/main/java/com/example/stylish/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/stylish/ui/MainActivity.kt
@@ -2,13 +2,16 @@ package com.example.stylish.ui
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.example.stylish.graphs.RootNavGraph
+import com.example.stylish.presentation.search.main.SearchMainViewModel
 import com.example.stylish.ui.theme.StylishTheme
 import dagger.hilt.android.AndroidEntryPoint
 


### PR DESCRIPTION
# Changes
* When searching, users can put some options or conditions. For example, sorting the items by in ascending order, in descending order, recommended, and freshness.
* Also users can set the price limit. There are two text fields, one for minimum price and the another for maximum price. By setting the price limits, users can see only the items that matches to the users' needs.
* Changed the logic of the way the search bar works. When the search bar is active, the trailing icon becomes a crossed 'X' which is 'Close' icon. And when users click on it, if there's some query, it clears the query and if there's nothing, it closes the expanded search bar. When the search bar is not active and there's some query, the icon becomes 'ArrowBack' icon. And when users click on it, it clears the query and also clears the search result so users can select the categories again.
<br>

# Video
![ezgif com-video-to-gif (1)](https://github.com/world2222/Stylish/assets/52661837/ef3a37d7-d932-4f04-9268-fd957282d6be)
